### PR TITLE
add gdp tooltip

### DIFF
--- a/newflow-frontend/src/components/Chart/index.js
+++ b/newflow-frontend/src/components/Chart/index.js
@@ -15,7 +15,21 @@ const Chart = () => {
 			type: 'value',
 			min: 1700000,
       max: 2200000,
-	  },
+		},
+		tooltip: {
+      trigger: 'axis',
+				axisPointer: {
+					type: 'shadow',
+				},
+			formatter: (params) => {
+				console.log(params)
+				return (
+					`$${params[0].data.toLocaleString()}` +
+					'<br/>' +
+					`${params[0].axisValue}년`
+				);
+			},
+		},
 	  series: [
 	    {
 	      data: [1835698.2, 1898192.6, 1924498.1, 1933152.4, 2057447.8],


### PR DESCRIPTION
gdp chart tooltip 을 만들었습니다.
<img width="1552" alt="Screen Shot 2022-04-24 at 5 45 13 PM" src="https://user-images.githubusercontent.com/56385667/164968210-46bdaffd-d823-4ddc-98b1-2dfc9a8d9b3e.png">

